### PR TITLE
Iceberg 1.3.0 jc streaming

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MicroBatches.java
+++ b/core/src/main/java/org/apache/iceberg/MicroBatches.java
@@ -92,7 +92,7 @@ public class MicroBatches {
 
     for (ManifestFile manifest : manifestFiles) {
       manifestIndexes.add(Pair.of(manifest, currentFileIndex));
-      currentFileIndex += manifest.addedFilesCount() + manifest.existingFilesCount();
+      currentFileIndex += manifest.addedFilesCount();
     }
 
     return manifestIndexes;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -310,16 +310,17 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsAdmissio
   }
 
   private Snapshot nextSnapshotSkippingOverNoneProcessable(Snapshot curSnapshot) {
-    curSnapshot = SnapshotUtil.snapshotAfter(table, curSnapshot.snapshotId());
-    while (!shouldProcess(curSnapshot)) {
-      LOG.debug("Skipping snapshot: {} of table {}", curSnapshot.snapshotId(), table.name());
-      // if the currentSnapShot was also the mostRecentSnapshot then break
-      if (curSnapshot.snapshotId() == table.currentSnapshot().snapshotId()) {
+    Snapshot next = SnapshotUtil.snapshotAfter(table, curSnapshot.snapshotId());
+    while (!shouldProcess(next)) {
+      LOG.debug("Skipping snapshot: {} of table {}", next.snapshotId(), table.name());
+      // if the last snapshot is a snapshot we should skip then return null
+      // indicating there is no next snapshot to consider
+      if (next.snapshotId() == table.currentSnapshot().snapshotId()) {
         return null;
       }
-      curSnapshot = SnapshotUtil.snapshotAfter(table, curSnapshot.snapshotId());
+      next = SnapshotUtil.snapshotAfter(table, next.snapshotId());
     }
-    return curSnapshot;
+    return next;
   }
 
   @Override

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -30,10 +30,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -498,6 +501,67 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testReadStreamWithSnapshotTypeRewriteDataFilesIgnoresReplace() throws Exception {
+    // fill table with some data
+    List<List<SimpleRecord>> expected = TEST_DATA_MULTIPLE_SNAPSHOTS;
+    appendDataAsMultipleSnapshots(expected);
+
+    makeRewriteDataFiles();
+
+    Iterable<Snapshot> snapshots = table.snapshots();
+    for (Snapshot s : snapshots) {
+      System.out.println(s.snapshotId());
+    }
+
+    Assert.assertEquals(
+        6,
+        microBatchCount(
+            ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")));
+  }
+
+  @Test
+  public void testReadStreamWithSnapshotType2RewriteDataFilesIgnoresReplace() throws Exception {
+    // fill table with some data
+    List<List<SimpleRecord>> expected = TEST_DATA_MULTIPLE_SNAPSHOTS;
+    appendDataAsMultipleSnapshots(expected);
+
+    makeRewriteDataFiles();
+    makeRewriteDataFiles();
+
+    Iterable<Snapshot> snapshots = table.snapshots();
+    for (Snapshot s : snapshots) {
+      System.out.println(s.snapshotId());
+    }
+
+    Assert.assertEquals(
+        6,
+        microBatchCount(
+            ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")));
+  }
+
+  @Test
+  public void testReadStreamWithSnapshotTypeRewriteDataFilesIgnoresReplaceFollowedByAppend()
+      throws Exception {
+    // fill table with some data
+    List<List<SimpleRecord>> expected = TEST_DATA_MULTIPLE_SNAPSHOTS;
+    appendDataAsMultipleSnapshots(expected);
+
+    makeRewriteDataFiles();
+
+    appendDataAsMultipleSnapshots(expected);
+
+    Iterable<Snapshot> snapshots = table.snapshots();
+    for (Snapshot s : snapshots) {
+      System.out.println(s.snapshotId());
+    }
+
+    Assert.assertEquals(
+        12,
+        microBatchCount(
+            ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")));
+  }
+
+  @Test
   public void testReadStreamWithSnapshotTypeReplaceIgnoresReplace() throws Exception {
     // fill table with some data
     List<List<SimpleRecord>> expected = TEST_DATA_MULTIPLE_SNAPSHOTS;
@@ -575,6 +639,29 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
     StreamingQuery query = startStream(SparkReadOptions.STREAMING_SKIP_OVERWRITE_SNAPSHOTS, "true");
     Assertions.assertThat(rowsAvailable(query))
         .containsExactlyInAnyOrderElementsOf(Iterables.concat(dataAcrossSnapshots));
+  }
+
+  /**
+   * We are testing that all the files in a rewrite snapshot are skipped Create a rewrite data files
+   * snapshot using existing files.
+   */
+  public void makeRewriteDataFiles() {
+    table.refresh();
+
+    // we are testing that all the files in a rewrite snapshot are skipped
+    // create a rewrite data files snapshot using existing files
+    RewriteFiles rewrite = table.newRewrite();
+    Iterable<Snapshot> it = table.snapshots();
+    for (Snapshot snapshot : it) {
+      if (snapshot.operation().equals(DataOperations.APPEND)) {
+        Iterable<DataFile> datafiles = snapshot.addedDataFiles(table.io());
+        for (DataFile datafile : datafiles) {
+          rewrite.addFile(datafile);
+          rewrite.deleteFile(datafile);
+        }
+      }
+    }
+    rewrite.commit();
   }
 
   /**


### PR DESCRIPTION
I fixed two issues with the Iceberg readStream
1- did not skip over entire rewrite snapshots (only did one file at a time)
2- kept pointing at the same position in commits. I suspect this was caused by a logic flaw

https://github.com/apache/iceberg/issues/8921
https://github.com/apache/iceberg/issues/8902