### PR TITLE
Iceberg 1.7.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ derby.log
 
 # jenv
 .java-version
+
+.vscode

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -148,7 +148,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
                   .projectedFieldNames(projectedFieldNames)
                   .tableName(table().name())
                   .snapshotId(snapshot.snapshotId())
-                  .filter(schema().asStruct(), filter(), context().caseSensitive())
+                  .filter(filter())
                   .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
                   .metadata(metadata)
                   .build();

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -148,9 +148,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
                   .projectedFieldNames(projectedFieldNames)
                   .tableName(table().name())
                   .snapshotId(snapshot.snapshotId())
-                  .filter(
-                      ExpressionUtil.sanitize(
-                          schema().asStruct(), filter(), context().caseSensitive()))
+                  .filter(schema().asStruct(), filter(), context().caseSensitive())
                   .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
                   .metadata(metadata)
                   .build();

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -96,7 +96,7 @@ subprojects {
 
           // CCCS modification starts
           groupId = 'cccs.ap.iceberg'
-          version = "1.7.0.0-SNAPSHOT"
+          version = "1.7.0.1-SNAPSHOT"
           // CCCS modification ends
           pom {
             name = 'Apache Iceberg'


### PR DESCRIPTION
We've been asked to not "sanitize" filter values of ScanReport.  These are sent to the metrics endpoint which are then send as audit logs by the REST Catalog.  This concern was raised as part of the revue of the platform when looking at auditing requirements for Spark.

Basically instead of this:
![image](https://github.com/user-attachments/assets/78d60e4b-b5db-4128-a57c-b6a9b06a1fa7)

We get this:
![image](https://github.com/user-attachments/assets/c2495ba2-09fa-426b-bcd9-3369519076db)

